### PR TITLE
Refactor(book): Now requires lower C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.8)
 project(OrderBook)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(lib)
-add_subdirectory(tests)
+
+# Если папка с проектом - не является подпапкой другого проекта
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # Добавляем юнит-тесты
+    add_subdirectory(tests)
+endif()

--- a/lib/include/orders/order_book.hpp
+++ b/lib/include/orders/order_book.hpp
@@ -31,9 +31,9 @@ public:
 
 	std::vector<Order> Top(int n = 10) const;
 
-	const std::map<Currency, OrderList, std::greater<>>& Bids() const;
+	const std::map<Currency, OrderList, std::greater<Currency>>& Bids() const;
 
-	const std::map<Currency, OrderList, std::less<>>& Asks() const;
+	const std::map<Currency, OrderList, std::less<Currency>>& Asks() const;
 
 	[[nodiscard]] bool Empty() const noexcept;
 
@@ -47,8 +47,8 @@ private:
 	inline void EraseFromMap(OrderListIter it);
 
 private:
-	std::map<Currency, OrderList, std::greater<>> bid_;
-	std::map<Currency, OrderList, std::less<>> ask_;
+	std::map<Currency, OrderList, std::greater<Currency>> bid_;
+	std::map<Currency, OrderList, std::less<Currency>> ask_;
 	std::unordered_map<OrderId, OrderListIter> resolver_;
 };
 

--- a/lib/src/order.cpp
+++ b/lib/src/order.cpp
@@ -1,5 +1,5 @@
 #include <orders/order.hpp>
-
+#include <tuple>
 
 OrderId GenerateID(const Order& o)
 {

--- a/lib/src/order_book.cpp
+++ b/lib/src/order_book.cpp
@@ -68,13 +68,13 @@ void OrderBook::EraseFromMap(OrderBook::OrderListIter it)
 
 }
 
-const std::map<Currency, OrderBook::OrderList, std::greater<>>&
+const std::map<Currency, OrderBook::OrderList, std::greater<Currency>>&
 OrderBook::Bids() const
 {
 	return bid_;
 }
 
-const std::map<Currency, OrderBook::OrderList, std::less<>>&
+const std::map<Currency, OrderBook::OrderList, std::less<Currency>>&
 OrderBook::Asks() const
 {
 	return ask_;


### PR DESCRIPTION
Now requires C++11, not 17.
Do not includes tests when included to other project